### PR TITLE
gpu name

### DIFF
--- a/Intro_to_Recommendation_Systems/Intro_Recommender.ipynb
+++ b/Intro_to_Recommendation_Systems/Intro_Recommender.ipynb
@@ -83,6 +83,7 @@
     "print(\"GPU: \", get_gpu_name())\n",
     "print(\"GPU memory: \", get_gpu_memory())\n",
     "print(\"CUDA: \", get_cuda_version())\n",
+    "print(torch.cuda.get_device_name())", #hopefully shows gpu name
     "\n",
     "%matplotlib inline\n",
     "%load_ext autoreload\n",


### PR DESCRIPTION
I dont know why, but my output looks like this:

OS:  win32
Python:  3.6.9 |Anaconda, Inc.| (default, Jul 30 2019, 14:00:49) [MSC v.1915 64 bit (AMD64)]
PyTorch:  1.2.0
Numpy:  1.16.5
Number of CPU processors:  16
[WinError 2] The system cannot find the file specified
GPU:  None
[WinError 2] The system cannot find the file specified
GPU memory:  None
CUDA:  None
GeForce RTX 2060 SUPER
The autoreload extension is already loaded. To reload it, use:
  %reload_ext autoreload

Although it could not find the cuda version or the gpu, printing out the device name shows my gpu